### PR TITLE
Copy unmatched files

### DIFF
--- a/lib/rake-pipeline/dsl.rb
+++ b/lib/rake-pipeline/dsl.rb
@@ -22,6 +22,9 @@ module Rake
       # @return [void]
       def self.evaluate(pipeline, &block)
         new(pipeline).instance_eval(&block)
+        copy_filter = Rake::Pipeline::ConcatFilter.new
+        copy_filter.output_name_generator = proc { |input| input }
+        pipeline.add_filter(copy_filter)
       end
 
       # Create a new {DSL} to configure a pipeline.

--- a/spec/rake_acceptance_spec.rb
+++ b/spec/rake_acceptance_spec.rb
@@ -20,10 +20,14 @@ HERE
 }
 HERE
 
-"app/stylesheets/sproutcore.css" => <<-HERE
+"app/stylesheets/sproutcore.css" => <<-HERE,
 #sproutcore {
   color: green;
 }
+HERE
+
+"app/index.html" => <<-HERE
+<html></html>
 HERE
 
 }
@@ -42,6 +46,10 @@ EXPECTED_CSS_OUTPUT = <<-HERE
 #sproutcore {
   color: green;
 }
+HERE
+
+EXPECTED_HTML_OUTPUT = <<-HERE
+<html></html>
 HERE
 
   before do
@@ -195,7 +203,6 @@ HERE
     end
 
     describe "using the matcher spec" do
-      it_behaves_like "the pipeline DSL"
 
       def output_should_exist(expected=EXPECTED_JS_OUTPUT)
         super
@@ -204,23 +211,27 @@ HERE
 
         File.exists?(css).should be_true
         File.read(css).should == EXPECTED_CSS_OUTPUT
+
+        html = File.join(tmp, "public/index.html")
+        File.exists?(html).should be_true
+        File.read(html).should == EXPECTED_HTML_OUTPUT
       end
+
+      it_behaves_like "the pipeline DSL"
 
       before do
         @pipeline = Rake::Pipeline.build do
           tmpdir "temporary"
-          input File.join(tmp, "app"), "**/*.{js,css}"
+          input File.join(tmp, "app"), "**/*.{js,css,html}"
           output "public"
 
           match "**/*.js" do
             filter strip_asserts_filter
+            filter concat_filter, "javascripts/application.js"
           end
 
-          filter(concat_filter) do |input|
-            location = File.dirname(input).split(File::SEPARATOR).last
-            extension = File.extname(input)
-
-            File.join(location, "application#{extension}")
+          match "**/*.css" do
+            filter concat_filter, "stylesheets/application.css"
           end
         end
       end


### PR DESCRIPTION
The docs say that unmatched files should be copied over to the output directory, but that doesn't actually happen. This fix just adds a copying filter to a pipeline after evaluating the DSL block. It's gross, so it won't hurt my feelings if someone else has a better idea.
