### PR TITLE
Filter parameters

### DIFF
--- a/lib/rake-pipeline/dsl.rb
+++ b/lib/rake-pipeline/dsl.rb
@@ -75,18 +75,12 @@ module Rake
       #   its outputs)
       #
       # @param [Class] filter_class the class of the filter.
-      # @param [String] string an output file name.
-      # @param [Proc] block an output file name generator
+      # @param [Array] ctor_args a list of arguments to pass
+      #   to the filter's constructor.
+      # @param [Proc] block an output file name generator.
       # @return [void]
-      def filter(filter_class, string=nil, &block)
-        block ||= if string
-          proc { string }
-        else
-          proc { |input| input }
-        end
-
-        filter = filter_class.new
-        filter.output_name_generator = block
+      def filter(filter_class, *ctor_args, &block)
+        filter = filter_class.new(*ctor_args, &block)
         pipeline.add_filter(filter)
       end
 

--- a/lib/rake-pipeline/filter.rb
+++ b/lib/rake-pipeline/filter.rb
@@ -68,6 +68,13 @@ module Rake
 
       attr_writer :file_wrapper_class
 
+      # @param [Proc] block a block to use as the Filter's
+      #   {#output_name_generator}.
+      def initialize(&block)
+        block ||= proc { |input| input }
+        @output_name_generator = block
+      end
+
       # Invoke this method in a subclass of Filter to declare that
       # it expects to work with BINARY data, and that data that is
       # not valid UTF-8 should be allowed.
@@ -77,6 +84,8 @@ module Rake
         define_method(:encoding) { "BINARY" }
       end
 
+      # @return [Class] the class to use as the wrapper for output
+      #   files.
       def file_wrapper_class
         @file_wrapper_class ||= FileWrapper
       end

--- a/lib/rake-pipeline/filter.rb
+++ b/lib/rake-pipeline/filter.rb
@@ -77,8 +77,8 @@ module Rake
         define_method(:encoding) { "BINARY" }
       end
 
-      def initialize(file_wrapper_class=FileWrapper)
-        @file_wrapper_class = file_wrapper_class
+      def file_wrapper_class
+        @file_wrapper_class ||= FileWrapper
       end
 
       # Set the input files to a list of FileWrappers. The filter
@@ -193,7 +193,7 @@ module Rake
       end
 
       def output_wrapper(file)
-        @file_wrapper_class.new(output_root, file, encoding)
+        file_wrapper_class.new(output_root, file, encoding)
       end
     end
   end

--- a/lib/rake-pipeline/filters/concat.rb
+++ b/lib/rake-pipeline/filters/concat.rb
@@ -28,6 +28,15 @@ module Rake
     #     end
     #   end
     class ConcatFilter < Rake::Pipeline::Filter
+      # @param [String] string the name of the output file to
+      #   concatenate inputs to.
+      # @param [Proc] block a block to use as the Filter's
+      #   {#output_name_generator}.
+      def initialize(string=nil, &block)
+        block = proc { string } if string
+        super(&block)
+      end
+
       # @method encoding
       # @return [String] the String +"BINARY"+
       processes_binary_files

--- a/spec/concat_filter_spec.rb
+++ b/spec/concat_filter_spec.rb
@@ -35,7 +35,8 @@ describe "ConcatFilter" do
 
     app = Rake::Application.new
 
-    filter = ::Rake::Pipeline::ConcatFilter.new(MemoryFileWrapper)
+    filter = ::Rake::Pipeline::ConcatFilter.new
+    filter.file_wrapper_class = MemoryFileWrapper
     filter.input_files = files
     filter.output_root = "/path/to/output"
     filter.output_name_generator = proc { "application.js" }

--- a/spec/concat_filter_spec.rb
+++ b/spec/concat_filter_spec.rb
@@ -27,20 +27,18 @@ describe "ConcatFilter" do
     end
   end
 
-  it "generates output" do
-    files = [
+  let(:input_files) {
+    [
       MemoryFileWrapper.new("/path/to/input", "javascripts/jquery.js", "UTF-8", "jQuery = {};"),
       MemoryFileWrapper.new("/path/to/input", "javascripts/sproutcore.js", "UTF-8", "SC = {};")
     ]
+  }
 
-    app = Rake::Application.new
-
-    filter = ::Rake::Pipeline::ConcatFilter.new
+  it "generates output" do
+    filter = Rake::Pipeline::ConcatFilter.new { "application.js" }
     filter.file_wrapper_class = MemoryFileWrapper
-    filter.input_files = files
     filter.output_root = "/path/to/output"
-    filter.output_name_generator = proc { "application.js" }
-    filter.rake_application = app
+    filter.input_files = input_files
 
     filter.output_files.should == [MemoryFileWrapper.new("/path/to/output", "application.js", "BINARY")]
 
@@ -50,5 +48,13 @@ describe "ConcatFilter" do
     file = MemoryFileWrapper.files["/path/to/output/application.js"]
     file.body.should == "jQuery = {};SC = {};"
     file.encoding.should == "BINARY"
+  end
+
+  it "accepts a string to use as the output file name" do
+    filter = Rake::Pipeline::ConcatFilter.new("app.js")
+    filter.file_wrapper_class = MemoryFileWrapper
+    filter.output_root = "/path/to/output"
+    filter.input_files = input_files
+    filter.output_files.should == [MemoryFileWrapper.new("/path/to/output", "app.js", "BINARY")]
   end
 end

--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -41,6 +41,12 @@ describe "Rake::Pipeline::Filter" do
     filter.output_name_generator.should == conversion
   end
 
+  it "accepts a block constructor argument to convert the input name into an output name" do
+    conversion = proc { |input| "application.js" }
+    new_filter = Rake::Pipeline::Filter.new(&conversion)
+    new_filter.output_name_generator.should == conversion
+  end
+
   describe "using the output_name proc to converting the input names into a hash" do
     before do
       filter.output_root = output_root

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -1,4 +1,7 @@
 describe "Rake::Pipeline" do
+  ConcatFilter = Rake::Pipeline::SpecHelpers::Filters::ConcatFilter
+  StripAssertsFilter = Rake::Pipeline::SpecHelpers::Filters::StripAssertsFilter
+
   let(:pipeline) { Rake::Pipeline.new }
 
   it "accepts a input root" do


### PR DESCRIPTION
In writing a Tilt filter class, I realized I wanted to be able to parameterize a filter. These commits change the Filter class so it no longer takes the file_wrapper_class as a parameter (but allows setting it after the fact), and changes DSL#filter to pass extra arguments on to the constructor when creating a filter instance. This way Filter subclasses can take whatever arguments they like.
