### PR TITLE
Add rakep clean

### DIFF
--- a/bin/rakep
+++ b/bin/rakep
@@ -3,21 +3,19 @@
 require "rake-pipeline"
 
 if ARGV[0] == "build"
-  config = "Assetfile"
-  pipeline_source = File.read(config)
-  pipeline = Rake::Pipeline.class_eval "build do\n#{pipeline_source}\nend", config, 1
+  pipeline = Rake::Pipeline.from_assetfile("Assetfile")
   pipeline.invoke
 else
   require "rake-pipeline/middleware"
   require "rack/server"
-  
+
   module Rake
     class Pipeline
       class Server < Rack::Server
         def app
           not_found = proc { [404, { "Content-Type" => "text/plain" }, ["not found"]] }
           config = "Assetfile"
-  
+
           Middleware.new(not_found, config)
         end
       end

--- a/bin/rakep
+++ b/bin/rakep
@@ -5,6 +5,9 @@ require "rake-pipeline"
 if ARGV[0] == "build"
   pipeline = Rake::Pipeline.from_assetfile("Assetfile")
   pipeline.invoke
+elsif ARGV[0] == "clean"
+  pipeline = Rake::Pipeline.from_assetfile("Assetfile")
+  pipeline.clobber
 else
   require "rake-pipeline/middleware"
   require "rack/server"

--- a/lib/rake-pipeline.rb
+++ b/lib/rake-pipeline.rb
@@ -156,6 +156,20 @@ module Rake
       pipeline
     end
 
+    # Build a new pipeline from the configuration contained in
+    # the file at the path given in +assetfile+. The file will
+    # be read and evaluated with Rake::Pipeline.build.
+    #
+    # @param [String] assetfile the file path to a an Assetfile.
+    #
+    # @see Rake::Pipeline.build
+    #
+    # @return [Rake::Pipeline] the newly configured pipeline
+    def self.from_assetfile(assetfile)
+      assetfile_source = File.read(assetfile)
+      Rake::Pipeline.class_eval "build do\n#{assetfile_source}\nend", assetfile, 1
+    end
+
     @@tmp_id = 0
 
     # Copy the current pipeline's attributes over.

--- a/lib/rake-pipeline.rb
+++ b/lib/rake-pipeline.rb
@@ -316,6 +316,15 @@ module Rake
       @filters.last.output_files unless @filters.empty?
     end
 
+    # Delete this pipeline's {#tmpdir} and all of its {#output_files}.
+    #
+    # @return [void]
+    def clobber
+      setup_filters
+      output_files.each { |file| FileUtils.rm_rf file.fullpath }
+      FileUtils.rm_rf tmpdir
+    end
+
   protected
     # Generate a new temporary directory name.
     #

--- a/lib/rake-pipeline.rb
+++ b/lib/rake-pipeline.rb
@@ -321,8 +321,14 @@ module Rake
     # @return [void]
     def clobber
       setup_filters
-      output_files.each { |file| FileUtils.rm_rf file.fullpath }
-      FileUtils.rm_rf tmpdir
+
+      filters.map(&:output_files).flatten.each do |file|
+        FileUtils.rm_rf file.fullpath
+      end
+
+      Dir["#{tmpdir}/rake-pipeline-tmp*"].each do |dir|
+        FileUtils.rm_rf dir
+      end
     end
 
   protected

--- a/lib/rake-pipeline/middleware.rb
+++ b/lib/rake-pipeline/middleware.rb
@@ -22,7 +22,7 @@ module Rake
         @app = app
 
         if pipeline.is_a?(String)
-          Rake::Pipeline.from_assetfile(pipeline)
+          pipeline = Rake::Pipeline.from_assetfile(pipeline)
         end
 
         @pipeline = pipeline

--- a/lib/rake-pipeline/middleware.rb
+++ b/lib/rake-pipeline/middleware.rb
@@ -22,8 +22,7 @@ module Rake
         @app = app
 
         if pipeline.is_a?(String)
-          pipeline_source = File.read(pipeline)
-          pipeline = Pipeline.class_eval "build do\n#{pipeline_source}\nend", pipeline, 1
+          Rake::Pipeline.from_assetfile(pipeline)
         end
 
         @pipeline = pipeline

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -214,19 +214,20 @@ describe "Rake::Pipeline" do
       pipeline.add_filter ConcatFilter.new
       # Add two filters so we know we need a tmp dir
       pipeline.add_filter ConcatFilter.new
-      pipeline.invoke
     end
 
     it "removes the pipeline's output files" do
+      pipeline.invoke
       output_files.each { |f| f.exists?.should be_true }
       pipeline.clobber
       output_files.each { |f| f.exists?.should be_false }
     end
 
-    it "removes the pipeline's tmp dir" do
-      File.exist?(pipeline.tmpdir).should be_true
+    it "cleans out the pipeline's tmp dir" do
+      pipeline.invoke
+      Dir["./temporary/rake-pipeline-tmp*"].should_not be_empty
       pipeline.clobber
-      File.exist?(pipeline.tmpdir).should be_false
+      Dir["./temporary/rake-pipeline-tmp*"].should be_empty
     end
-  end
+   end
 end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -53,10 +53,28 @@ describe "Rake::Pipeline" do
     end
   end
 
-  shared_examples_for "when working with input" do
+  module InputHelpers
     def input_file(path, root=File.join(tmp, "app/assets"))
       Rake::Pipeline::FileWrapper.new root, path
     end
+
+    def output_file(path, root=File.join(tmp, "public"))
+      input_file(path, root)
+    end
+
+    def create_files(files)
+      Array(files).each do |file|
+        mkdir_p File.dirname(file.fullpath)
+
+        File.open(file.fullpath, "w") do |file|
+          file.write "// This is #{file.path}\n"
+        end
+      end
+    end
+  end
+
+  shared_examples_for "when working with input" do
+    include InputHelpers
 
     let(:files) do
       %w(javascripts/jquery.js javascripts/sproutcore.js).map do |filename|
@@ -70,15 +88,7 @@ describe "Rake::Pipeline" do
 
     before do
       Rake.application = Rake::Application.new
-
-      files.each do |file|
-        mkdir_p File.dirname(file.fullpath)
-
-        File.open(file.fullpath, "w") do |file|
-          file.write "// This is #{file.path}\n"
-        end
-      end
-
+      create_files(files)
       setup_roots
       setup_input(pipeline)
       pipeline.output_root = "public"
@@ -147,10 +157,6 @@ describe "Rake::Pipeline" do
   describe "when using multiple input roots" do
     it_behaves_like "when working with input"
 
-    def input_file(path, root=File.join(tmp, "app/assets"))
-      Rake::Pipeline::FileWrapper.new root, path
-    end
-
     def setup_roots
       pipeline.add_input File.join(tmp, 'tmp1', "app/assets"), '**/*.js'
       pipeline.add_input File.join(tmp, 'tmp2', "app/assets"), '**/*.css'
@@ -185,6 +191,42 @@ describe "Rake::Pipeline" do
         end
         pipeline.input_files = wrappers
       end
+    end
+  end
+
+  describe "clobbering a pipeline" do
+    include InputHelpers
+
+    let(:input_files) do
+      %w(jquery.js ember.js).map { |f| input_file(f) }
+    end
+
+    let(:output_files) do
+      input_files.map { |f| output_file(f.path) }
+    end
+
+    before do
+      Rake.application = Rake::Application.new
+      create_files(input_files)
+      pipeline.add_input "app/assets"
+      pipeline.output_root = "public"
+      pipeline.tmpdir = "temporary"
+      pipeline.add_filter ConcatFilter.new
+      # Add two filters so we know we need a tmp dir
+      pipeline.add_filter ConcatFilter.new
+      pipeline.invoke
+    end
+
+    it "removes the pipeline's output files" do
+      output_files.each { |f| f.exists?.should be_true }
+      pipeline.clobber
+      output_files.each { |f| f.exists?.should be_false }
+    end
+
+    it "removes the pipeline's tmp dir" do
+      File.exist?(pipeline.tmpdir).should be_true
+      pipeline.clobber
+      File.exist?(pipeline.tmpdir).should be_false
     end
   end
 end

--- a/spec/rake_acceptance_spec.rb
+++ b/spec/rake_acceptance_spec.rb
@@ -213,6 +213,23 @@ HERE
       end
     end
 
+    describe "the raw pipeline DSL (read from an Assetfile)" do
+      it_behaves_like "the pipeline DSL"
+
+      before do
+        File.open(File.join(tmp, "Assetfile"), "w") { |file| file.write(<<-HERE) }
+          require "#{tmp}/../support/spec_helpers/filters"
+          tmpdir "temporary"
+          input "#{tmp}", "app/javascripts/*.js"
+          filter Rake::Pipeline::ConcatFilter, "javascripts/application.js"
+          filter Rake::Pipeline::SpecHelpers::Filters::StripAssertsFilter
+          output "public"
+        HERE
+
+        @pipeline = Rake::Pipeline.from_assetfile("Assetfile")
+      end
+    end
+
     describe "using the matcher spec" do
       def output_should_exist(expected=EXPECTED_JS_OUTPUT)
         super

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,50 +10,8 @@ end
 require "rake-pipeline"
 require "rake-pipeline/filters"
 
-class Rake::Pipeline
-  module SpecHelpers
-
-    # TODO: OS agnostic modules
-    module FileUtils
-      def mkdir_p(dir)
-        system "mkdir", "-p", dir
-      end
-
-      def touch(file)
-        system "touch", file
-      end
-
-      def rm_rf(dir)
-        system "rm", "-rf", dir
-      end
-
-      def touch_p(file)
-        dir = File.dirname(file)
-        mkdir_p dir
-        touch file
-      end
-
-      def age_existing_files
-        old_time = Time.now - 10
-        Dir[File.join(tmp, "**/*.js")].each do |file|
-          File.utime(old_time, old_time, file)
-        end
-      end
-    end
-
-    module Filters
-      ConcatFilter = Rake::Pipeline::ConcatFilter
-
-      class StripAssertsFilter < Rake::Pipeline::Filter
-        def generate_output(inputs, output)
-          inputs.each do |input|
-            output.write input.read.gsub(%r{^\s*assert\(.*\)\s*;?\s*$}m, '')
-          end
-        end
-      end
-    end
-  end
-end
+require "support/spec_helpers/file_utils"
+require "support/spec_helpers/filters"
 
 RSpec.configure do |config|
   original = Dir.pwd

--- a/spec/support/spec_helpers/file_utils.rb
+++ b/spec/support/spec_helpers/file_utils.rb
@@ -1,0 +1,35 @@
+class Rake::Pipeline
+  module SpecHelpers
+
+    # TODO: OS agnostic modules
+    module FileUtils
+      def mkdir_p(dir)
+        system "mkdir", "-p", dir
+      end
+
+      def touch(file)
+        system "touch", file
+      end
+
+      def rm_rf(dir)
+        system "rm", "-rf", dir
+      end
+
+      def touch_p(file)
+        dir = File.dirname(file)
+        mkdir_p dir
+        touch file
+      end
+
+      def age_existing_files
+        old_time = Time.now - 10
+        Dir[File.join(tmp, "**/*.js")].each do |file|
+          File.utime(old_time, old_time, file)
+        end
+      end
+    end
+
+  end
+end
+
+

--- a/spec/support/spec_helpers/filters.rb
+++ b/spec/support/spec_helpers/filters.rb
@@ -1,0 +1,16 @@
+class Rake::Pipeline
+  module SpecHelpers
+
+    module Filters
+      ConcatFilter = Rake::Pipeline::ConcatFilter
+
+      class StripAssertsFilter < Rake::Pipeline::Filter
+        def generate_output(inputs, output)
+          inputs.each do |input|
+            output.write input.read.gsub(%r{^\s*assert\(.*\)\s*;?\s*$}m, '')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've added a Rake::Pipeline#clobber method and a `rakep clean` command. They both delete the temp directory and the pipeline's output files.
I called the command `clean` b/c I think that's the more common usage, but the method is #clobber to avoid confusion with #invoke_clean.
