### PR TITLE
Glob ordering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ rvm:
   - rbx
 
 notifications:
-  email: wycats@gmail.com
+  email:
+    - wycats@gmail.com
+    - dudley@steambone.org

--- a/lib/rake-pipeline.rb
+++ b/lib/rake-pipeline.rb
@@ -229,7 +229,7 @@ module Rake
         end
       end
 
-      result
+      result.sort
     end
 
     # for Pipelines, this is every file, but it may be overridden

--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -101,8 +101,8 @@ describe "Rake::Pipeline::Filter" do
       filter.output_name_generator = output_name_generator
       outputs = filter.outputs
 
-      outputs.keys.should == [output_file("jquery.js"), output_file("sproutcore.js")]
-      outputs.values.should == [[input_file("jquery.js"), input_file("jquery-ui.js")], [input_file("sproutcore.js")]]
+      outputs.keys.sort.should == [output_file("jquery.js"), output_file("sproutcore.js")]
+      outputs.values.sort.should == [[input_file("jquery.js"), input_file("jquery-ui.js")], [input_file("sproutcore.js")]]
 
       filter.output_files.should == [output_file("jquery.js"), output_file("sproutcore.js")]
     end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -170,7 +170,7 @@ describe "Rake::Pipeline" do
 
     def setup_input(pipeline)
       Dir.chdir("app/assets") do
-        files = Dir["javascripts/**/*.js"]
+        files = Dir["javascripts/**/*.js"].sort
         wrappers = files.map do |file|
           Rake::Pipeline::FileWrapper.new(File.join(tmp, "app/assets"), file)
         end


### PR DESCRIPTION
This should fix our ci failures, or some of them at the very least. It passes on 1.9 and 1.8 on Mac OS X, and 1.9 on Linux.
