### PR TITLE
Add Rake::Pipeline::PipelineFinalizingFilter

### DIFF
--- a/lib/rake-pipeline/dsl.rb
+++ b/lib/rake-pipeline/dsl.rb
@@ -1,5 +1,6 @@
 module Rake
   class Pipeline
+
     # This class exists purely to provide a convenient DSL for
     # configuring a pipeline.
     #
@@ -22,9 +23,7 @@ module Rake
       # @return [void]
       def self.evaluate(pipeline, &block)
         new(pipeline).instance_eval(&block)
-        copy_filter = Rake::Pipeline::ConcatFilter.new
-        copy_filter.output_name_generator = proc { |input| input }
-        pipeline.add_filter(copy_filter)
+        pipeline.add_filter(Rake::Pipeline::PipelineFinalizingFilter.new)
       end
 
       # Create a new {DSL} to configure a pipeline.
@@ -158,5 +157,4 @@ module Rake
     end
   end
 end
-
 

--- a/lib/rake-pipeline/filters.rb
+++ b/lib/rake-pipeline/filters.rb
@@ -1,2 +1,3 @@
 require "rake-pipeline/filters/concat_filter"
 require "rake-pipeline/filters/ordering_concat_filter"
+require "rake-pipeline/filters/pipeline_finalizing_filter"

--- a/lib/rake-pipeline/filters/pipeline_finalizing_filter.rb
+++ b/lib/rake-pipeline/filters/pipeline_finalizing_filter.rb
@@ -1,0 +1,18 @@
+module Rake
+  class Pipeline
+    # @private
+    #
+    # A built-in filter that copies a pipeline's generated files over
+    # to its output.
+    class PipelineFinalizingFilter < ConcatFilter
+
+      # @return [Array[FileWrapper]] a list of the pipeline's
+      # output files, excluding any files that were originally
+      # inputs to the pipeline, meaning they weren't processed
+      # by any filter and should not be copied to the output.
+      def input_files
+        super.reject { |file| pipeline.input_files.include?(file) }
+      end
+    end
+  end
+end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -33,8 +33,10 @@ describe "Rake::Pipeline::Project" do
     (Digest::SHA1.new << File.read(assetfile_path)).to_s
   end
 
+  let(:unmatched_file) { input_file("junk.txt") }
+
   let(:input_files) do
-    %w(jquery.js ember.js).map { |f| input_file(f) }
+    [input_file("jquery.js"), input_file("ember.js"), unmatched_file]
   end
 
   let(:output_files) do
@@ -83,6 +85,7 @@ describe "Rake::Pipeline::Project" do
       digest_dir = File.join(tmp, "tmp", "rake-pipeline-#{assetfile_digest}")
       File.exist?(digest_dir).should be_true
     end
+
   end
 
   describe "#invoke_clean" do
@@ -144,6 +147,12 @@ describe "Rake::Pipeline::Project" do
       output_files.each { |f| f.should exist }
       project.clean
       output_files.each { |f| f.should_not exist }
+    end
+
+    it "leaves the pipeline's unmatched input files alone" do
+      project.invoke
+      project.clean
+      unmatched_file.should exist
     end
   end
 

--- a/spec/rake_acceptance_spec.rb
+++ b/spec/rake_acceptance_spec.rb
@@ -26,8 +26,12 @@ HERE
 }
 HERE
 
-"app/index.html" => <<-HERE
+"app/index.html" => <<-HERE,
 <html></html>
+HERE
+
+"app/junk.txt" => <<-HERE
+junk
 HERE
 
 }
@@ -256,6 +260,9 @@ HERE
         html = File.join(tmp, "public/index.html")
         File.exists?(html).should be_true
         File.read(html).should == EXPECTED_HTML_OUTPUT
+
+        junk = File.join(tmp, "public/junk.txt")
+        File.exists?(junk).should be_false
       end
 
       it_behaves_like "the pipeline DSL"
@@ -263,7 +270,7 @@ HERE
       before do
         @pipeline = Rake::Pipeline.build do
           tmpdir "temporary"
-          input File.join(tmp, "app"), "**/*.{js,css,html}"
+          input File.join(tmp, "app")
           output "public"
 
           match "**/*.js" do
@@ -273,6 +280,10 @@ HERE
 
           match "**/*.css" do
             filter concat_filter, "stylesheets/application.css"
+          end
+
+          match "**/*.html" do
+            filter concat_filter
           end
         end
       end
@@ -321,6 +332,9 @@ HERE
         html = File.join(tmp, "public/index.html")
         File.exists?(html).should be_true
         File.read(html).should == EXPECTED_HTML_OUTPUT
+
+        junk = File.join(tmp, "public/junk.txt")
+        File.exists?(junk).should be_false
       end
 
       before do
@@ -329,8 +343,8 @@ HERE
 
         @pipeline = Rake::Pipeline.build do
           tmpdir "temporary"
-          input File.join(tmp1, "app"), "**/*.{js,css,html}"
-          input File.join(tmp2, "app"), "**/*.{js,css,html}"
+          input File.join(tmp1, "app")
+          input File.join(tmp2, "app")
 
           output "public"
 
@@ -341,6 +355,10 @@ HERE
 
           match "**/*.css" do
             filter concat_filter, "stylesheets/application.css"
+          end
+
+          match "**/*.html" do
+            filter concat_filter
           end
         end
       end


### PR DESCRIPTION
Change the filter we add to the end of every pipeline from a ConcatFilter (which copies all inputs) to a PipelineFinalizingFilter, which only copies the files that the pipeline created. This closes #30. I'm not entirely sold on the implementation, but I believe the behavior is correct.
