### PR TITLE
rakep build enhancements

### DIFF
--- a/bin/rakep
+++ b/bin/rakep
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 require "rake-pipeline"
-Rake::Pipeline::Runner.start
+Rake::Pipeline::CLI.start

--- a/lib/rake-pipeline.rb
+++ b/lib/rake-pipeline.rb
@@ -5,6 +5,7 @@ require "rake-pipeline/dsl"
 require "rake-pipeline/matcher"
 require "rake-pipeline/error"
 require "rake-pipeline/runner"
+require "rake-pipeline/cli"
 
 if defined?(Rails::Railtie)
   require "rake-pipeline/railtie"

--- a/lib/rake-pipeline/cli.rb
+++ b/lib/rake-pipeline/cli.rb
@@ -1,0 +1,58 @@
+require "thor"
+
+module Rake
+  class Pipeline
+    class CLI < Thor
+      class_option :assetfile, :default => "Assetfile", :aliases => "-c"
+      default_task :server
+
+      desc "build", "Build the project."
+      method_option :pretend, :type => :boolean, :aliases => "-p"
+      method_option :clean, :type => :boolean, :aliases => "-C"
+      def build
+        if options[:pretend]
+          runner.pipeline.setup_filters
+          runner.output_files.each do |file|
+            say_status :create, relative_path(file)
+          end
+        else
+          options[:clean] ? runner.clean : runner.cleanup_tmpdir
+          runner.invoke
+        end
+      end
+
+      desc "clean", "Remove the pipeline's temporary and output files."
+      method_option :pretend, :type => :boolean, :aliases => "-p"
+      def clean
+        if options[:pretend]
+          runner.pipeline.setup_filters
+          runner.files_to_clean.each do |file|
+            say_status :remove, relative_path(file)
+          end
+        else
+          runner.clean
+        end
+      end
+
+      desc "server", "Run the Rake::Pipeline preview server."
+      def server
+        require "rake-pipeline/server"
+        Rake::Pipeline::Server.new.start
+      end
+
+    private
+      def runner
+        @runner ||= Rake::Pipeline::Runner.new(options[:assetfile])
+      end
+
+      # @param [FileWrapper|String] path
+      # @return [String] The path to the file with the current
+      #   directory stripped out.
+      def relative_path(path)
+        pathstr = path.respond_to?(:fullpath) ? path.fullpath : path
+        pathstr.sub(%r|#{Dir.pwd}/|, '')
+      end
+    end
+  end
+end
+

--- a/lib/rake-pipeline/filter.rb
+++ b/lib/rake-pipeline/filter.rb
@@ -79,6 +79,7 @@ module Rake
       def initialize(&block)
         block ||= proc { |input| input }
         @output_name_generator = block
+        @input_files = []
       end
 
       # Invoke this method in a subclass of Filter to declare that

--- a/lib/rake-pipeline/middleware.rb
+++ b/lib/rake-pipeline/middleware.rb
@@ -21,7 +21,7 @@ module Rake
       #   Assetfile to use to build a pipeline, or an existing pipeline.
       def initialize(app, pipeline)
         @app = app
-        @runner = Rake::Pipeline::Runner.from_assetfile(pipeline)
+        @runner = Rake::Pipeline::Runner.new(pipeline)
       end
 
       # Automatically compiles your assets if required and

--- a/lib/rake-pipeline/precompile.rake
+++ b/lib/rake-pipeline/precompile.rake
@@ -2,7 +2,7 @@ namespace :assets do
   desc "Precompile assets using Rake::Pipeline"
   task :precompile do
     config = Rails.application.config.rake_pipeline_assetfile
-    Rake::Pipeline::Runner.from_assetfile(config).invoke(:build, [])
+    Rake::Pipeline::Runner.new(config).invoke
   end
 end
 

--- a/lib/rake-pipeline/runner.rb
+++ b/lib/rake-pipeline/runner.rb
@@ -31,7 +31,7 @@ module Rake
       def build
         if options["pretend"]
           pipeline.setup_filters
-          pipeline.output_files.each { |dir| say_status(:create, dir.fullpath) }
+          pipeline.output_files.each { |dir| say_status(:create, relative_path(dir)) }
         else
           options["clean"] ? invoke(:clean) : cleanup_tmpdir
           pipeline.invoke
@@ -141,6 +141,14 @@ module Rake
         obsolete_tmpdirs +
           ["#{pipeline.tmpdir}/#{digested_tmpdir}"] +
           pipeline.output_files.map(&:fullpath)
+      end
+
+      # @param [FileWrapper] path
+      # @return [String] The path to the file with the current
+      #   directory stripped out.
+      def relative_path(path)
+        pathstr = path.respond_to?(:fullpath) ? path.fullpath : path
+        pathstr.sub(%r|#{Dir.pwd}/|, '')
       end
     end
   end

--- a/lib/rake-pipeline/runner.rb
+++ b/lib/rake-pipeline/runner.rb
@@ -6,7 +6,7 @@ module Rake
     # it from an Assetfile and recreating it if the Assetfile
     # changes.
     #
-    class Runner < Thor
+    class Runner
       # @return [Pipeline] the pipeline this Runner is controlling.
       attr_reader :pipeline
 
@@ -19,95 +19,87 @@ module Rake
       #   was created without an Assetfile.
       attr_reader :assetfile_digest
 
-      class_option :assetfile, :default => "Assetfile", :aliases => "-c"
-
-      default_task :server
-
-      desc "build", "Build the project."
-      method_option :pretend, :type => :boolean, :aliases => "-p"
-      method_option :clean, :type => :boolean, :aliases => "-C"
-      def build
-        if options["pretend"]
-          pipeline.setup_filters
-          pipeline.output_files.each { |dir| say_status(:create, relative_path(dir)) }
-        else
-          options["clean"] ? invoke(:clean) : cleanup_tmpdir
-          pipeline.invoke
-        end
-      end
-
-      desc "clean", "Remove the pipeline's temporary and output files."
-      method_option :pretend, :type => :boolean, :aliases => "-p"
-      def clean
-        pipeline.setup_filters
-        if options["pretend"]
-          files_to_clobber.each { |dir| say_status(:remove, relative_path(dir)) }
-        else
-          files_to_clobber.each { |dir| FileUtils.rm_rf(dir) }
-        end
-      end
-
-      desc "server", "Run the Rake::Pipeline preview server."
-      def server
-        require "rake-pipeline/server"
-        Rake::Pipeline::Server.new.start
-      end
-
       # @param [String|Rake::Pipeline] assetfile_or_pipeline
       #   if this a String, create a Rake::Pipeline from the
       #   Assetfile at that path. If it's a Rake::Pipeline,
       #   just wrap that pipeline.
-      def self.from_assetfile(assetfile_or_pipeline)
-        if assetfile_or_pipeline.is_a?(String)
-          new([], :assetfile => File.expand_path(assetfile_or_pipeline))
-        else
-          new([], :pipeline => assetfile_or_pipeline)
-        end
-      end
-
-      def initialize(*)
-        super
+      def initialize(assetfile_or_pipeline)
         @invoke_mutex = Mutex.new
-        if options["pipeline"]
-          @pipeline = options["pipeline"]
-        else
-          @assetfile_path = File.expand_path(options["assetfile"])
+        if assetfile_or_pipeline.is_a?(String)
+          @assetfile_path = File.expand_path(assetfile_or_pipeline)
           build_pipeline
+        else
+          @pipeline = assetfile_or_pipeline
         end
       end
 
-      no_tasks do
-        # Clean out old tmp directories from the pipeline's
-        # {Rake::Pipeline#tmpdir}.
-        #
-        # @return [void]
-        def cleanup_tmpdir
-          pipeline.setup_filters
-          obsolete_tmpdirs.each { |dir| FileUtils.rm_rf(dir) }
-        end
+      # Invoke the pipeline.
+      #
+      # @see Rake::Pipeline#invoke
+      def invoke
+        pipeline.invoke
+      end
 
-        # Invoke the pipeline, detecting any changes to the Assetfile
-        # and rebuilding the pipeline if necessary.
-        #
-        # @return [void]
-        # @see Rake::Pipeline#invoke_clean
-        def invoke_clean
-          @invoke_mutex.synchronize do
-            if assetfile_path
-              assetfile_source = File.read(assetfile_path)
-              if digest(assetfile_source) != assetfile_digest
-                build_pipeline(assetfile_source)
-              end
+      # Invoke the pipeline, detecting any changes to the Assetfile
+      # and rebuilding the pipeline if necessary.
+      #
+      # @return [void]
+      # @see Rake::Pipeline#invoke_clean
+      def invoke_clean
+        @invoke_mutex.synchronize do
+          if assetfile_path
+            assetfile_source = File.read(assetfile_path)
+            if digest(assetfile_source) != assetfile_digest
+              build_pipeline(assetfile_source)
             end
-            pipeline.invoke_clean
           end
+          pipeline.invoke_clean
         end
+      end
 
-        # @return [String] the directory name to use as the pipeline's
-        #   {Rake::Pipeline#tmpsubdir}.
-        def digested_tmpdir
-          "rake-pipeline-#{assetfile_digest}"
+      # Remove the pipeline's temporary and output files.
+      def clean
+        files_to_clean.each { |file| FileUtils.rm_rf(file) }
+      end
+
+      # Clean out old tmp directories from the pipeline's
+      # {Rake::Pipeline#tmpdir}.
+      #
+      # @return [void]
+      def cleanup_tmpdir
+        obsolete_tmpdirs.each { |dir| FileUtils.rm_rf(dir) }
+      end
+
+      # @return [String] the directory name to use as the pipeline's
+      #   {Rake::Pipeline#tmpsubdir}.
+      def digested_tmpdir
+        "rake-pipeline-#{assetfile_digest}"
+      end
+
+      # @return Array[String] a list of the paths to temporary directories
+      #   that don't match the pipline's Assetfile digest.
+      def obsolete_tmpdirs
+        if File.directory?(pipeline.tmpdir)
+          Dir["#{pipeline.tmpdir}/rake-pipeline-*"].sort.reject do |dir|
+            dir == "#{pipeline.tmpdir}/#{digested_tmpdir}"
+          end
+        else
+          []
         end
+      end
+
+      # @return Array[String] a list of files to delete to completely clean
+      #   out a pipeline's temporary and output files.
+      def files_to_clean
+        obsolete_tmpdirs +
+          ["#{pipeline.tmpdir}/#{digested_tmpdir}"] +
+          pipeline.output_files.map(&:fullpath)
+      end
+
+      # @return [Array[FileWrapper]] a list of the files that
+      #   will be generated when this Runner is invoked.
+      def output_files
+        pipeline.output_files
       end
 
     private
@@ -126,34 +118,6 @@ module Rake
       # @return [String] the SHA1 digest of the given string.
       def digest(str)
         Digest::SHA1.hexdigest(str)
-      end
-
-      # @return Array[String] a list of the paths to temporary directories
-      #   that don't match the pipline's Assetfile digest.
-      def obsolete_tmpdirs
-        if File.directory?(pipeline.tmpdir)
-          Dir["#{pipeline.tmpdir}/rake-pipeline-*"].sort.reject do |dir|
-            dir == "#{pipeline.tmpdir}/#{digested_tmpdir}"
-          end
-        else
-          []
-        end
-      end
-
-      # @return Array[String] a list of files to delete to completely clean
-      #   out a pipeline's temporary and output files.
-      def files_to_clobber
-        obsolete_tmpdirs +
-          ["#{pipeline.tmpdir}/#{digested_tmpdir}"] +
-          pipeline.output_files.map(&:fullpath)
-      end
-
-      # @param [FileWrapper] path
-      # @return [String] The path to the file with the current
-      #   directory stripped out.
-      def relative_path(path)
-        pathstr = path.respond_to?(:fullpath) ? path.fullpath : path
-        pathstr.sub(%r|#{Dir.pwd}/|, '')
       end
     end
   end

--- a/lib/rake-pipeline/runner.rb
+++ b/lib/rake-pipeline/runner.rb
@@ -27,12 +27,13 @@ module Rake
 
       desc "build", "Build the project."
       method_option :pretend, :type => :boolean, :aliases => "-p"
+      method_option :clean, :type => :boolean, :aliases => "-C"
       def build
         if options["pretend"]
           pipeline.setup_filters
           pipeline.output_files.each { |dir| say_status(:create, dir.fullpath) }
         else
-          cleanup_tmpdir
+          options["clean"] ? invoke(:clean) : cleanup_tmpdir
           pipeline.invoke
         end
       end

--- a/lib/rake-pipeline/runner.rb
+++ b/lib/rake-pipeline/runner.rb
@@ -119,7 +119,7 @@ module Rake
 
       # @return [String] the SHA1 digest of the given string.
       def digest(str)
-        (Digest::SHA1.new << str).to_s
+        Digest::SHA1.hexdigest(str)
       end
 
       # @return Array[String] a list of the paths to temporary directories

--- a/lib/rake-pipeline/runner.rb
+++ b/lib/rake-pipeline/runner.rb
@@ -7,8 +7,6 @@ module Rake
     # changes.
     #
     class Runner < Thor
-      include Thor::Actions
-
       # @return [Pipeline] the pipeline this Runner is controlling.
       attr_reader :pipeline
 
@@ -42,7 +40,11 @@ module Rake
       method_option :pretend, :type => :boolean, :aliases => "-p"
       def clean
         pipeline.setup_filters
-        files_to_clobber.each { |dir| remove_dir dir }
+        if options["pretend"]
+          files_to_clobber.each { |dir| say_status(:remove, relative_path(dir)) }
+        else
+          files_to_clobber.each { |dir| FileUtils.rm_rf(dir) }
+        end
       end
 
       desc "server", "Run the Rake::Pipeline preview server."
@@ -80,7 +82,7 @@ module Rake
         # @return [void]
         def cleanup_tmpdir
           pipeline.setup_filters
-          obsolete_tmpdirs.each { |dir| remove_dir dir }
+          obsolete_tmpdirs.each { |dir| FileUtils.rm_rf(dir) }
         end
 
         # Invoke the pipeline, detecting any changes to the Assetfile

--- a/lib/rake-pipeline/runner.rb
+++ b/lib/rake-pipeline/runner.rb
@@ -67,6 +67,7 @@ module Rake
 
       def initialize(*)
         super
+        @invoke_mutex = Mutex.new
         if options["pipeline"]
           @pipeline = options["pipeline"]
         else
@@ -91,13 +92,15 @@ module Rake
         # @return [void]
         # @see Rake::Pipeline#invoke_clean
         def invoke_clean
-          if assetfile_path
-            assetfile_source = File.read(assetfile_path)
-            if digest(assetfile_source) != assetfile_digest
-              build_pipeline(assetfile_source)
+          @invoke_mutex.synchronize do
+            if assetfile_path
+              assetfile_source = File.read(assetfile_path)
+              if digest(assetfile_source) != assetfile_digest
+                build_pipeline(assetfile_source)
+              end
             end
+            pipeline.invoke_clean
           end
-          pipeline.invoke_clean
         end
 
         # @return [String] the directory name to use as the pipeline's


### PR DESCRIPTION
I've cleaned up this pull request: https://github.com/livingsocial/rake-pipeline/pull/37 so it should be easier to follow. The high points:
- Uses a faster digest method
- adds `rakep build --clean`
- adds a mutex around assetfile checking / pipeline rebuilding
- separates command-line stuff out of Runner
- quiets `rakep build` and `rakep clean`
- fixes a bug where an Assetfile is read twice when running the server
