### PR TITLE
Add a `require "digest"` to Project

### DIFF
--- a/lib/rake-pipeline/project.rb
+++ b/lib/rake-pipeline/project.rb
@@ -1,4 +1,5 @@
 require "thor"
+require "digest"
 
 module Rake
   class Pipeline


### PR DESCRIPTION
We're using Digest, but I forgot to require it.
