### PR TITLE
Fix massive performance regression in PipelineFinalizingFilter

### DIFF
--- a/lib/rake-pipeline/filters/pipeline_finalizing_filter.rb
+++ b/lib/rake-pipeline/filters/pipeline_finalizing_filter.rb
@@ -11,7 +11,8 @@ module Rake
       # inputs to the pipeline, meaning they weren't processed
       # by any filter and should not be copied to the output.
       def input_files
-        super.reject { |file| pipeline.input_files.include?(file) }
+        pipeline_input_files = pipeline.input_files
+        super.reject { |file| pipeline_input_files.include?(file) }
       end
     end
   end


### PR DESCRIPTION
Don't recalculate a pipeline's input files on every iteration.
