### PR TITLE
Change the default rakep command to from server to build.

### DIFF
--- a/lib/rake-pipeline/cli.rb
+++ b/lib/rake-pipeline/cli.rb
@@ -4,7 +4,7 @@ module Rake
   class Pipeline
     class CLI < Thor
       class_option :assetfile, :default => "Assetfile", :aliases => "-c"
-      default_task :server
+      default_task :build
 
       desc "build", "Build the project."
       method_option :pretend, :type => :boolean, :aliases => "-p"


### PR DESCRIPTION
By popular demand, this changes `rakep` with no arguments from `rakep server` to `rakep build`. Seems like it makes more sense for a build tool to build by default.
