### PR TITLE
Added support for regexp in Rake::Pipeline::Matcher pattern

### DIFF
--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -111,4 +111,28 @@ describe "a matcher" do
       file_wrapper("javascripts/backbone.js")
     ]
   end
+
+  it "accepts Regexp as glob" do
+    regexp = /application\.erb/
+    @matcher.glob = regexp
+
+    @matcher.glob.should == regexp
+  end
+
+  it "underestands regexp globs" do
+    regexp = /^*(?<!\.coffee)\.js$/i
+
+    @matcher.input_files << file_wrapper("application.coffee.js")
+    @matcher.input_files << file_wrapper("application.engine.js")
+
+    output_root = File.join(tmp, "tmp1")
+
+    should_match_glob regexp, [
+      file_wrapper("jquery.js", :encoding => "BINARY", :root => output_root),
+      file_wrapper("sproutcore.js", :encoding => "BINARY", :root => output_root),
+      file_wrapper("application.engine.js", :encoding => "BINARY", :root => output_root),
+      file_wrapper("sproutcore.css"),
+      file_wrapper("application.coffee.js")
+    ]
+  end
 end


### PR DESCRIPTION
Hi.

I'm trying to select specific files in my matcher, like this:

in my views directory I have files:
about.en.erb
index.erb

I want to match only files without locale information in name (wihout en part), so matcher should look something like:

``` ruby
match /^views(\/.*|\/)[^\/]*(?<!\.en)\.erb$/i do
end
```

This was imposilbe to achieve with StringScanner, so in the end I monkey patched Rake::Pipeline::Matcher, to accept Regexp in my application

I think that support for regexp gives lot of flexibility.
Let me know what you think
