### PR TITLE
rakep watch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ gem "simplecov", :require => false
 gem "yard"
 gem "rdiscount"
 gem "pry"
+gem "fssm"

--- a/lib/rake-pipeline/cli.rb
+++ b/lib/rake-pipeline/cli.rb
@@ -38,6 +38,12 @@ module Rake
         Rake::Pipeline::Server.new.start
       end
 
+      desc "watch", "Build the project when inputs change."
+      def watch
+        require "rake-pipeline/watcher"
+        Rake::Pipeline::Watcher.new(project).start
+      end
+
     private
       def project
         @project ||= Rake::Pipeline::Project.new(options[:assetfile])

--- a/lib/rake-pipeline/watcher.rb
+++ b/lib/rake-pipeline/watcher.rb
@@ -46,8 +46,12 @@ module Rake
       def generate_build_proc(project)
         Proc.new do
           puts "#{Time.now}: building project..."
-          project.invoke_clean
-          puts "done"
+          begin
+            project.invoke_clean
+            puts "done"
+          rescue Exception => e
+            puts "RAKEP ERROR: #{e.message}"
+          end
         end
       end
 

--- a/lib/rake-pipeline/watcher.rb
+++ b/lib/rake-pipeline/watcher.rb
@@ -1,0 +1,56 @@
+require "fssm"
+
+module Rake
+  class Pipeline
+    class Watcher
+
+      def initialize(project)
+        @project = project
+      end
+
+      def start
+        project = @project
+        build_proc = generate_build_proc(project)
+        monitor = FSSM::Monitor.new
+
+        watched_inputs(project).each do |root, input_glob|
+          monitor.path root do
+            glob input_glob
+            update &build_proc
+            create &build_proc
+            delete &build_proc
+          end
+        end
+
+        # Build it once when we start up, and then start watching for changes.
+        build_proc.call
+        monitor.run
+      end
+
+
+      # Get the paths and globs to watch for changes, which is all the inputs
+      #   plus the Assetfile
+      def watched_inputs(project)
+        inputs = {"." => ['Assetfile']}
+        project.pipelines.each do |pipeline|
+          pipeline.inputs.each do |k, v|
+            inputs[k] ||= []
+            inputs[k] << v
+          end
+        end
+        inputs
+      end
+
+      private
+
+      def generate_build_proc(project)
+        Proc.new do
+          puts "#{Time.now}: building project..."
+          project.invoke
+          puts "done"
+        end
+      end
+
+    end
+  end
+end

--- a/lib/rake-pipeline/watcher.rb
+++ b/lib/rake-pipeline/watcher.rb
@@ -46,7 +46,7 @@ module Rake
       def generate_build_proc(project)
         Proc.new do
           puts "#{Time.now}: building project..."
-          project.invoke
+          project.invoke_clean
           puts "done"
         end
       end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -68,4 +68,18 @@ describe "Rake::Pipeline::CLI" do
       rakep "server"
     end
   end
+
+  describe "watcher" do
+    let(:watcher) { double "watcher" }
+
+    before do
+      require 'rake-pipeline/watcher'
+      Rake::Pipeline::Watcher.stub(:new).and_return(watcher)
+    end
+
+    it "starts a Rake::Pipeline::Watcher" do
+      watcher.should_receive :start
+      rakep "watch"
+    end
+  end
 end

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -1,0 +1,45 @@
+require "rake-pipeline/watcher"
+
+describe "Rake::Pipeline::Watcher" do
+  attr_reader :project, :watcher, :monitor
+
+  assetfile_source = <<-HERE.gsub(/^ {4}/, '')
+    output "public"
+    input "#{tmp}", "app/**/*" do
+      concat { |input| input.sub(%r|^app/|, '') }
+    end
+  HERE
+
+  let(:assetfile_path){ File.join(tmp, "Assetfile") }
+
+  before do
+    File.open(assetfile_path, "w") { |file| file.write(assetfile_source) }
+
+    @project = Rake::Pipeline::Project.new(assetfile_path)
+    @project.stub(:invoke)
+
+    @watcher = Rake::Pipeline::Watcher.new(@project)
+    @watcher.stub(:puts)
+
+    @monitor = double("monitor")
+    @monitor.stub(:path)
+    @monitor.stub(:run)
+    FSSM::Monitor.stub(:new).and_return(@monitor)
+  end
+
+  it "builds on initialization" do
+    project.should_receive :invoke
+    watcher.start
+  end
+
+  it "finds the correct paths to watch" do
+    paths = watcher.watched_inputs(project)
+    paths['.'].should == ["Assetfile"]
+    paths[tmp].should == ["app/**/*"]
+  end
+
+  it "starts the file watcher" do
+    monitor.should_receive :run
+    watcher.start
+  end
+end

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -16,7 +16,7 @@ describe "Rake::Pipeline::Watcher" do
     File.open(assetfile_path, "w") { |file| file.write(assetfile_source) }
 
     @project = Rake::Pipeline::Project.new(assetfile_path)
-    @project.stub(:invoke_clean)
+    @project.stub(:invoke)
 
     @watcher = Rake::Pipeline::Watcher.new(@project)
     @watcher.stub(:puts)
@@ -28,7 +28,7 @@ describe "Rake::Pipeline::Watcher" do
   end
 
   it "builds on initialization" do
-    project.should_receive :invoke_clean
+    project.should_receive :invoke
     watcher.start
   end
 

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -16,7 +16,7 @@ describe "Rake::Pipeline::Watcher" do
     File.open(assetfile_path, "w") { |file| file.write(assetfile_source) }
 
     @project = Rake::Pipeline::Project.new(assetfile_path)
-    @project.stub(:invoke)
+    @project.stub(:invoke_clean)
 
     @watcher = Rake::Pipeline::Watcher.new(@project)
     @watcher.stub(:puts)
@@ -28,7 +28,7 @@ describe "Rake::Pipeline::Watcher" do
   end
 
   it "builds on initialization" do
-    project.should_receive :invoke
+    project.should_receive :invoke_clean
     watcher.start
   end
 


### PR DESCRIPTION
Greetings. I was very happy to find the rake pipeline project - thanks!

I wanted to be able to have it automatically update my output for cases when I need to use the output files directly (rather than going through rakep server). I saw that someone else had also requested this feature ( https://github.com/livingsocial/rake-pipeline/issues/36 ) so I went ahead and implemented "rakep watch" using the the FSSM gem. It watches for changes in your input directories and the Assetfile itself, and just does an invoke_clean to rebuild everything when any changes are detected.

Please let me know if you have any feedback. And thanks again!
