### PR TITLE
Rakep Watch, using Listen gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ gem "simplecov", :require => false
 gem "yard"
 gem "rdiscount"
 gem "pry"
+gem "listen"

--- a/lib/rake-pipeline/cli.rb
+++ b/lib/rake-pipeline/cli.rb
@@ -35,7 +35,11 @@ module Rake
       desc "server", "Run the Rake::Pipeline preview server."
       def server
         require "rake-pipeline/server"
+        require "rake-pipeline/watcher"
+        watcher = Rake::Pipeline::Watcher.new(project)
+        watcher.start(false)
         Rake::Pipeline::Server.new.start
+        watcher.stop
       end
 
       desc "watch", "Build the project when inputs change."

--- a/lib/rake-pipeline/cli.rb
+++ b/lib/rake-pipeline/cli.rb
@@ -38,6 +38,12 @@ module Rake
         Rake::Pipeline::Server.new.start
       end
 
+      desc "watch", "Build the project when inputs change."
+      def watch
+        require "rake-pipeline/watcher"
+        Rake::Pipeline::Watcher.new(project).start
+      end
+
     private
       def project
         @project ||= Rake::Pipeline::Project.new(options[:assetfile])

--- a/lib/rake-pipeline/middleware.rb
+++ b/lib/rake-pipeline/middleware.rb
@@ -30,7 +30,6 @@ module Rake
       # @param [Hash] env a Rack environment
       # @return [Array(Fixnum, Hash, #each)] A rack response
       def call(env)
-        project.invoke_clean
         path = env["PATH_INFO"]
 
         if filename = file_for(path)

--- a/lib/rake-pipeline/watcher.rb
+++ b/lib/rake-pipeline/watcher.rb
@@ -1,0 +1,70 @@
+require "listen"
+require "logger"
+
+module Rake
+  class Pipeline
+    class Watcher
+      attr_reader :logger
+
+      def initialize(project)
+        @project = project
+        @listeners = []
+        @logger = Logger.new(STDOUT)
+      end
+
+      def start(blocking = true)
+        project = @project
+
+        build_proc = Proc.new do |modified, added, removed|
+          # Determine if we need to do a clean build, which is only the case if
+          #   files were added/deleted, or the Assetfile itself changed.
+          clean = added.any? || removed.any? || modified.include?('Assetfile')
+
+          logger.info "#{Time.now}:#{" reloading &" if clean} building project..."
+          begin
+            method = clean ? :invoke_clean : :invoke
+            project.send method
+            logger.info "done"
+          rescue Exception => e
+            logger.error "RAKEP ERROR: #{e.message}"
+          end
+        end
+
+        # Watch for file changes in the inputs or the Assetfile.
+        watched_inputs(project).each do |root, input_glob|
+          listener = Listen.to(root, :relative_paths => true)
+          listener = listener.filter(input_glob) if input_glob.is_a?(Regexp)
+          listener = listener.change(&build_proc)
+          @listeners << listener
+        end
+
+        # Build it once when we start up, and then start watching for changes.
+        build_proc.call(['Assetfile'], [], [])
+        @listeners.each{|l| l.start(blocking) }
+      end
+
+      def stop
+        @listeners.each{|l| l.stop }
+        @listeners = []
+      end
+
+
+      # Get the paths and globs to watch for changes, which is all the inputs
+      #   plus the Assetfile
+      def watched_inputs(project)
+        inputs = {"." => [/^Assetfile$/]}
+        project.pipelines.each do |pipeline|
+          pipeline.inputs.each do |k, v|
+            inputs[k] ||= true
+            # TODO: Support a regex filter here if we can reuse the Matcher code that
+            #       converts a glob into a regex.
+            # inputs[k] ||= []
+            # inputs[k] << v
+          end
+        end
+        inputs
+      end
+
+    end
+  end
+end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -68,4 +68,18 @@ describe "Rake::Pipeline::CLI" do
       rakep "server"
     end
   end
+
+  describe "watcher" do
+    let(:watcher) { double "watcher" }
+
+    before do
+      require 'rake-pipeline/watcher'
+      Rake::Pipeline::Watcher.stub(:new).and_return(watcher)
+    end
+
+    it "starts a Rake::Pipeline::Watcher" do
+      watcher.should_receive :start
+      rakep "watch"
+    end
+  end
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -57,14 +57,19 @@ describe "Rake::Pipeline::CLI" do
 
   describe "server" do
     let(:server) { double "server" }
+    let(:watcher) { double "watcher" }
 
     before do
       require 'rake-pipeline/server'
       Rake::Pipeline::Server.stub(:new).and_return(server)
+      require 'rake-pipeline/watcher'
+      Rake::Pipeline::Watcher.stub(:new).and_return(watcher)
     end
 
     it "starts a Rake::Pipeline::Server" do
       server.should_receive :start
+      watcher.should_receive :start
+      watcher.should_receive :stop
       rakep "server"
     end
   end

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -1,0 +1,46 @@
+require "rake-pipeline/watcher"
+
+describe "Rake::Pipeline::Watcher" do
+  attr_reader :project, :watcher, :listener
+
+  assetfile_source = <<-HERE.gsub(/^ {4}/, '')
+    output "public"
+    input "#{tmp}", "app/**/*" do
+      concat { |input| input.sub(%r|^app/|, '') }
+    end
+  HERE
+
+  let(:assetfile_path){ File.join(tmp, "Assetfile") }
+
+  before do
+    File.open(assetfile_path, "w") { |file| file.write(assetfile_source) }
+
+    @project = Rake::Pipeline::Project.new(assetfile_path)
+    @project.stub(:invoke)
+
+    @watcher = Rake::Pipeline::Watcher.new(@project)
+    Logger.any_instance.stub(:add)
+
+    @listener = double("listener")
+    @listener.stub(:change).and_return(@listener)
+    @listener.stub(:filter).and_return(@listener)
+    @listener.stub(:start).and_return(@listener)
+    Listen.stub(:to).and_return(@listener)
+  end
+
+  it "builds on initialization" do
+    project.should_receive :invoke_clean
+    watcher.start
+  end
+
+  xit "finds the correct paths to watch" do
+    paths = watcher.watched_inputs(project)
+    paths['.'].should == ["Assetfile"]
+    paths[tmp].should == ["app/**/*"]
+  end
+
+  it "starts the file watcher" do
+    listener.should_receive :start
+    watcher.start
+  end
+end

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -17,6 +17,7 @@ describe "Rake::Pipeline::Watcher" do
 
     @project = Rake::Pipeline::Project.new(assetfile_path)
     @project.stub(:invoke)
+    @project.stub(:invoke_clean)
 
     @watcher = Rake::Pipeline::Watcher.new(@project)
     Logger.any_instance.stub(:add)
@@ -29,10 +30,11 @@ describe "Rake::Pipeline::Watcher" do
   end
 
   it "builds on initialization" do
-    project.should_receive :invoke_clean
+    project.should_receive(:invoke_clean).once
     watcher.start
   end
 
+  # TODO: regex support for input filters
   xit "finds the correct paths to watch" do
     paths = watcher.watched_inputs(project)
     paths['.'].should == ["Assetfile"]
@@ -42,5 +44,36 @@ describe "Rake::Pipeline::Watcher" do
   it "starts the file watcher" do
     listener.should_receive :start
     watcher.start
+  end
+
+  it "does a clean build when a file is added." do
+    listener.stub(:change).and_yield([], ['added_file'], []).and_return(listener)
+    project.should_receive(:invoke_clean).at_least(2).times
+    watcher.start
+  end
+
+  it "does a clean build when a file is removed." do
+    listener.stub(:change).and_yield([], [], ['removed_file']).and_return(listener)
+    project.should_receive(:invoke_clean).at_least(2).times
+    watcher.start
+  end
+
+  it "does a clean build when the Assetfile is modified." do
+    listener.stub(:change).and_yield(['Assetfile'], [], []).and_return(listener)
+    project.should_receive(:invoke_clean).at_least(2).times
+    watcher.start
+  end
+
+  it "does a regular build when a non-Assetfile is modified." do
+    listener.stub(:change).and_yield(['modified_file'], [], []).and_return(listener)
+    project.should_receive(:invoke_clean).once
+    project.should_receive(:invoke).at_least(1).times
+    watcher.start
+  end
+
+  it "stops the listeners when it is stopped." do
+    watcher.start
+    listener.should_receive(:stop).at_least(1).times
+    watcher.stop
   end
 end


### PR DESCRIPTION
This is a new attempt at the rakep watch functionality, using the Listen gem instead of FSSM for file monitoring. In addition, as requested on my previous pull request, I have modified the server to not worry about rebuilding the outputs. Instead, "rakep server" starts up a non-blocking watcher to rebuild the outputs as needed.

There are a couple questions I had, the first of which is actually a todo in the code:
1. The Listen gem uses regex filters, instead of globs, to filter the set of files that it watches. However, the Pipeline inputs are defined to take only globs. I see the Matcher now has a private method to turn a glob into a regex. I would like to expose that so it can be used by the Watcher on the pipeline input glob as well, perhaps by moving it into a new module. Does that sound reasonable?
2. I deleted a few specs from the Middleware, since the Middleware is no longer responsible for rebuilding the output. I could add these back as integration specs if there is interest. It would probably need to involve some "sleep" to give time for the Watcher to rebuild the files in a separate thread, which seems a little clunky.

Please let me know your thoughts on these two items, and any other general thoughts, and I will be happy to finish it up. Thanks!
