### PR TITLE
Make glob order well-defined

### DIFF
--- a/lib/rake-pipeline.rb
+++ b/lib/rake-pipeline.rb
@@ -246,7 +246,7 @@ module Rake
 
       @inputs.each do |root, glob|
         expanded_root = File.expand_path(root)
-        files = Dir[File.join(expanded_root, glob)].select { |f| File.file?(f) }
+        files = Dir[File.join(expanded_root, glob)].sort.select { |f| File.file?(f) }
 
         files.each do |file|
           relative_path = file.sub(%r{^#{Regexp.escape(expanded_root)}/}, '')

--- a/lib/rake-pipeline/middleware.rb
+++ b/lib/rake-pipeline/middleware.rb
@@ -58,7 +58,7 @@ module Rake
 
       def file_for(path)
         project.pipelines.each do |pipeline|
-          file = Dir[File.join(pipeline.output_root, path)].first
+          file = Dir[File.join(pipeline.output_root, path)].sort.first
           return file unless file.nil?
         end
         nil


### PR DESCRIPTION
I'm just shotgunning all the Dir[...] calls here. :)

Having fixed glob order avoids flickering tests. Also, when generated
files are checked in, undefined glob order can produce long diffs.

---

Inspired by a flickering test on Ember.
