### PR TITLE
Fixes for MacRuby

### DIFF
--- a/lib/rake-pipeline.rb
+++ b/lib/rake-pipeline.rb
@@ -259,7 +259,9 @@ module Rake
 
     # for Pipelines, this is every file, but it may be overridden
     # by subclasses
-    alias eligible_input_files input_files
+    def eligible_input_files
+      input_files
+    end
 
     # @return [Rake::Application] The Rake::Application to install
     #   rake tasks onto. Defaults to Rake.application

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,8 @@
-unless ENV["TRAVIS"]
+def macruby?
+  defined?(RUBY_ENGINE) && RUBY_ENGINE == 'macruby'
+end
+
+unless ENV["TRAVIS"] || macruby?
   require 'simplecov'
   SimpleCov.start do
     add_group "lib", "lib"


### PR DESCRIPTION
With these two changes, the rake-pipeline test suite passes on MacRuby. I have not built a site on top of it using MacRuby yet, so I may have more as I go, we'll see. I had to make two changes:

In `rake-pipeline.rb` we are creating this method by aliasing `input_files`. Then we are overriding this method in `rake-pipeline/matcher.rb`. However, because of when we're requiring `rake-pipeline/matcher.rb` the override is happening **before** the alias. On MacRuby, when the alias runs it clobbers the override causing all input files to match, not just the ones matching the glob in `Assetfile`. For an extremely simplified example see https://gist.github.com/3728490.

SimpleCov is not supported by MacRuby. I pulled this snippet from https://github.com/intridea/multi_json/blob/master/spec/helper.rb to not include SimpleCov on that platform.
