### PR TITLE
Raise an error if tmpdir is an input

### DIFF
--- a/lib/rake-pipeline.rb
+++ b/lib/rake-pipeline.rb
@@ -106,6 +106,13 @@ module Rake
   #     # up until this point, as well as the HTML files.
   #   end
   class Pipeline
+    class Error < StandardError ; end
+    class TmpInputError < StandardError
+      def to_s
+        "tmpdir cannot be part of the input!"
+      end
+    end
+
     # @return [Hash[String, String]] the directory paths for the input files
     #   and their matching globs.
     attr_accessor :inputs
@@ -304,6 +311,9 @@ module Rake
     def invoke
       @invoke_mutex.synchronize do
         self.rake_application = Rake::Application.new unless @rake_application
+
+        input_directories = inputs.keys.collect { |f| File.expand_path(f) }
+        raise TmpInputError if input_directories.include? tmpdir
 
         setup
 

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -176,6 +176,14 @@ describe "Rake::Pipeline" do
 
         Rake.application.tasks.size.should == 0
       end
+
+      it "raises an error when tmp is an input" do
+        pipeline.tmpdir = "app/assets"
+
+        expect {
+          pipeline.invoke
+        }.to raise_error(Rake::Pipeline::TmpInputError, /tmpdir/)
+      end
     end
   end
 


### PR DESCRIPTION
I wasn't sure exactly where to put this code so I put it here. This will prevent users from failing hard like I did. This only raises an error if tmpdir is input. This does not raise an error if directories inside tmp are inputs. Example:

``` ruby
# Raises an error
input "tmp" do 
  # pipeline stuff
end

tmpdir "tmp"
```

``` ruby
# does not raise an error since the tmp itself is not an input
tmpdir "tmp"

input "app/assets", "tmp/builds" do
  # pipeline stuff
end
```
