### PR TITLE
GsubFilter for stripping and replacing

### DIFF
--- a/lib/rake-pipeline/dsl/pipeline_dsl.rb
+++ b/lib/rake-pipeline/dsl/pipeline_dsl.rb
@@ -196,6 +196,25 @@ module Rake
           end
         end
         alias_method :copy, :concat
+
+        # A helper method for adding a gsub filter to the pipeline.
+        # It takes the same arguments as String#gsub. The output file
+        # cannot be changed. 
+        #
+        # @see GsubFilter#initialize
+        def gsub(*args, &block)
+          filter(Rake::Pipeline::GsubFilter, *args, &block)
+        end
+        alias_method :replace, :gsub
+
+        # A helper method like gsub, but removes everything
+        # specified by the matcher. The matcher is the first argument
+        # passed to String#gsub
+        #
+        # @see String#gsub
+        def strip(matcher)
+          filter(Rake::Pipeline::GsubFilter, matcher, '')
+        end
       end
     end
   end

--- a/lib/rake-pipeline/filters.rb
+++ b/lib/rake-pipeline/filters.rb
@@ -1,3 +1,4 @@
 require "rake-pipeline/filters/concat_filter"
 require "rake-pipeline/filters/ordering_concat_filter"
 require "rake-pipeline/filters/pipeline_finalizing_filter"
+require "rake-pipeline/filters/gsub_filter"

--- a/lib/rake-pipeline/filters/gsub_filter.rb
+++ b/lib/rake-pipeline/filters/gsub_filter.rb
@@ -1,13 +1,48 @@
-class Rake::Pipeline
-  class GsubFilter < Filter
-    def initialize(*args, &block)
-      @args, @bock = args, block
-      super() { |input| input }
-    end
+module Rake
+  class Pipeline
+    # A built in filter that applies String#gsub behavior.
+    #
+    # @example
+    #   !!!ruby
+    #   Pipeline.build do
+    #     input "app/assets", "**/*.js"
+    #     output "public"
+    #
+    #     # replace javascript comments
+    #     filter(Rake::Pipeline::GsubFilter, /\//\w+$/, '')
+    #
+    #     # another example
+    #     filter(Rake::Pipeline::GsubFilter, /\//\w+$/) do |comment|
+    #       # process comment in some way
+    #       # comment is replaced with this block's 
+    #       # return value
+    #     end
+    #   end
+    class GsubFilter < Filter
+      # Arguments mimic String#gsub
+      #
+      # @see String#gsub
+      def initialize(*args, &block)
+        @args, @bock = args, block
+        super() { |input| input }
+      end
 
-    def generate_output(inputs, output)
-      inputs.each do |input|
-        output.write input.read.gsub(*@args, &@block)
+      # Implement the {#generate_output} method required by
+      # the {Filter} API. In this case, simply loop through
+      # the inputs and write String#gsub content to the output
+      #
+      # Recall that this method will be called once for each
+      # unique output file.
+      #
+      # @param [Array<FileWrapper>] inputs an Array of
+      #   {FileWrapper} objects representing the inputs to
+      #   this filter.
+      # @param [FileWrapper] a single {FileWrapper} object
+      #   representing the output.
+      def generate_output(inputs, output)
+        inputs.each do |input|
+          output.write input.read.gsub(*@args, &@block)
+        end
       end
     end
   end

--- a/lib/rake-pipeline/filters/gsub_filter.rb
+++ b/lib/rake-pipeline/filters/gsub_filter.rb
@@ -1,0 +1,14 @@
+class Rake::Pipeline
+  class GsubFilter < Filter
+    def initialize(*args, &block)
+      @args, @bock = args, block
+      super() { |input| input }
+    end
+
+    def generate_output(inputs, output)
+      inputs.each do |input|
+        output.write input.read.gsub(*@args, &@block)
+      end
+    end
+  end
+end

--- a/spec/dsl/pipeline_dsl_spec.rb
+++ b/spec/dsl/pipeline_dsl_spec.rb
@@ -131,4 +131,26 @@ describe "Rake::Pipeline::PipelineDSL" do
       filter.should be_kind_of(Rake::Pipeline::RejectMatcher)
     end
   end
+
+  describe "#gsub" do
+    it "creates a GsubFilter" do
+      dsl.gsub
+      filter.should be_kind_of(Rake::Pipeline::GsubFilter)
+    end
+  end
+
+  describe "#replace" do
+    it "creates a GsubFilter" do
+      dsl.replace
+      filter.should be_kind_of(Rake::Pipeline::GsubFilter)
+    end
+  end
+
+  describe "#strip" do
+    it "creates a GsubFilter with no replacement" do
+      regex = /mock/
+      dsl.should_receive(:filter).with(Rake::Pipeline::GsubFilter, regex, '')
+      dsl.strip /mock/
+    end
+  end
 end

--- a/spec/gsub_filter_spec.rb
+++ b/spec/gsub_filter_spec.rb
@@ -1,5 +1,6 @@
 describe "GsubFilter" do
   MemoryFileWrapper = Rake::Pipeline::SpecHelpers::MemoryFileWrapper
+  MemoryManifest = Rake::Pipeline::SpecHelpers::MemoryManifest
 
   let(:input_files) {
     [
@@ -8,8 +9,10 @@ describe "GsubFilter" do
   }
 
   it "generates output" do
-    filter = Rake::Pipeline::GsubFilter.new "Ember.assert", 'foo'
+    filter = Rake::Pipeline::GsubFilter.new "Ember.assert", "foo"
     filter.file_wrapper_class = MemoryFileWrapper
+    filter.manifest = MemoryManifest.new
+
     filter.output_root = "/path/to/output"
     filter.input_files = input_files
 
@@ -28,6 +31,8 @@ describe "GsubFilter" do
     end
 
     filter.file_wrapper_class = MemoryFileWrapper
+    filter.manifest = MemoryManifest.new
+
     filter.output_root = "/path/to/output"
     filter.input_files = input_files
 

--- a/spec/gsub_filter_spec.rb
+++ b/spec/gsub_filter_spec.rb
@@ -1,0 +1,50 @@
+describe "GsubFilter" do
+  MemoryFileWrapper = Rake::Pipeline::SpecHelpers::MemoryFileWrapper
+
+  let(:input_files) {
+    [
+      MemoryFileWrapper.new("/path/to/input", "ember.js", "UTF-8", "Ember.assert"),
+    ]
+  }
+
+  it "generates output" do
+    filter = Rake::Pipeline::GsubFilter.new "Ember.assert", 'foo'
+    filter.file_wrapper_class = MemoryFileWrapper
+    filter.output_root = "/path/to/output"
+    filter.input_files = input_files
+
+    filter.output_files.should == [MemoryFileWrapper.new("/path/to/output", "ember.js", "UTF-8")]
+
+    tasks = filter.generate_rake_tasks
+    tasks.each(&:invoke)
+
+    file = MemoryFileWrapper.files["/path/to/output/ember.js"]
+    file.body.should == "foo"
+  end
+
+  it "accepts a block to use with gsub" do
+    filter = Rake::Pipeline::GsubFilter.new "Ember.assert" do 
+      "foo"
+    end
+
+    filter.file_wrapper_class = MemoryFileWrapper
+    filter.output_root = "/path/to/output"
+    filter.input_files = input_files
+
+    filter.output_files.should == [MemoryFileWrapper.new("/path/to/output", "ember.js", "UTF-8")]
+
+    tasks = filter.generate_rake_tasks
+    tasks.each(&:invoke)
+
+    file = MemoryFileWrapper.files["/path/to/output/ember.js"]
+    file.body.should == "foo"
+  end
+
+  it "use the input name for output" do
+    filter = Rake::Pipeline::GsubFilter.new
+    filter.file_wrapper_class = MemoryFileWrapper
+    filter.output_root = "/path/to/output"
+    filter.input_files = input_files
+    filter.output_files.should == [MemoryFileWrapper.new("/path/to/output", "ember.js", "UTF-8")]
+  end
+end


### PR DESCRIPTION
See docs and tests. 

Here are the additions to the DSL:

``` ruby
match "**/*js" do
  # basic gsubbing
  gsub /\/\/\w+$/, "no comments allowed!"

  # block syntax works
  gsub /.+/ do |match|
    # process things
  end

  # gsub filter with no replacement
  strip /Ember.assert\(.+\);/
end
```
