### PR TITLE
Gsub fix

### DIFF
--- a/lib/rake-pipeline/dsl/pipeline_dsl.rb
+++ b/lib/rake-pipeline/dsl/pipeline_dsl.rb
@@ -225,8 +225,6 @@ module Rake
         alias_method :copy, :concat
 
         # A helper method for adding a gsub filter to the pipeline.
-        # It takes the same arguments as String#gsub. The output file
-        # cannot be changed. 
         #
         # @see GsubFilter#initialize
         def gsub(*args, &block)

--- a/lib/rake-pipeline/filters/gsub_filter.rb
+++ b/lib/rake-pipeline/filters/gsub_filter.rb
@@ -10,29 +10,29 @@ module Rake
     #
     #     # replace javascript comments
     #     filter(Rake::Pipeline::GsubFilter, /\//\w+$/, '')
-    #
-    #     # another example
-    #     filter(Rake::Pipeline::GsubFilter, /\//\w+$/) do |comment|
-    #       # process comment in some way
-    #       # comment is replaced with this block's 
-    #       # return value
-    #     end
     #   end
     class GsubFilter < Filter
-      # Arguments mimic String#gsub
+      # Arguments mimic String#gsub with one notable exception. 
+      # String#gsub accepts a block where $1, $2, and friends are
+      # accessible. Due to Ruby's scoping rules of these variables
+      # they are not accssible inside the block itself. Instead they
+      # are passed in as additional arguments. Here's an example:
+      #
+      # @example
+      #   !!!ruby
+      #   Rake::Pipeline::GsubFilter.new /(\w+)\s(\w+)/ do |entire_match, capture1, capture2|
+      #     # process the match
+      #   end
       #
       # @see String#gsub
       def initialize(*args, &block)
-        @args, @bock = args, block
+        @args, @block = args, block
         super() { |input| input }
       end
 
       # Implement the {#generate_output} method required by
       # the {Filter} API. In this case, simply loop through
-      # the inputs and write String#gsub content to the output
-      #
-      # Recall that this method will be called once for each
-      # unique output file.
+      # the inputs and write String#gsub content to the output.
       #
       # @param [Array<FileWrapper>] inputs an Array of
       #   {FileWrapper} objects representing the inputs to
@@ -41,7 +41,14 @@ module Rake
       #   representing the output.
       def generate_output(inputs, output)
         inputs.each do |input|
-          output.write input.read.gsub(*@args, &@block)
+          if @block
+            content = input.read.gsub(*@args) do |match|
+              @block.call match, *$~.captures
+            end
+            output.write content
+          else
+            output.write input.read.gsub(*@args)
+          end
         end
       end
     end


### PR DESCRIPTION
@block was written incorrectly in the previous commit. This commit
also fixes test issues against that occur when running tests in random
order. Setting a fresh rake application each time fixes the issue. Tasks
are marked as already invoked when using the same application since the
same input and output files are used for every test.

This commit also fixes a problem with "global" regex variables in the
gsub block. $1, $2, $~ are supposed to be accessible inside the block.
This does not work when passing in a block from another context. $1 and
such are actually local variables not global variables. The matches are
passed in as block arguments instead. The documenation has been updated
to reflect this important quirk.
