### PR TITLE
Remove rename invoke_clean to invoke & drop invoke

### DIFF
--- a/lib/rake-pipeline/middleware.rb
+++ b/lib/rake-pipeline/middleware.rb
@@ -30,7 +30,7 @@ module Rake
       # @param [Hash] env a Rack environment
       # @return [Array(Fixnum, Hash, #each)] A rack response
       def call(env)
-        project.invoke_clean
+        project.invoke
         path = env["PATH_INFO"]
 
         if project.maps.has_key?(path)

--- a/lib/rake-pipeline/project.rb
+++ b/lib/rake-pipeline/project.rb
@@ -103,23 +103,12 @@ module Rake
         self
       end
 
-      # Invoke all of the project's pipelines.
-      #
-      # @see Rake::Pipeline#invoke
-      def invoke
-        @invoke_mutex.synchronize do
-          manifest.read_manifest
-          pipelines.each(&:invoke)
-          manifest.write_manifest
-        end
-      end
-
       # Invoke all of the project's pipelines, detecting any changes
       # to the Assetfile and rebuilding the pipelines if necessary.
       #
       # @return [void]
-      # @see Rake::Pipeline#invoke_clean
-      def invoke_clean
+      # @see Rake::Pipeline#invoke
+      def invoke
         @invoke_mutex.synchronize do
           if assetfile_path
             source = File.read(assetfile_path)
@@ -129,7 +118,7 @@ module Rake
           end
 
           manifest.read_manifest
-          pipelines.each(&:invoke_clean)
+          pipelines.each(&:invoke)
           manifest.write_manifest
         end
       end

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -163,7 +163,7 @@ describe "Rake::Pipeline" do
       pipeline.input_files = [input_file("foo.bar", pipeline.tmpdir)]
 
       expect {
-        pipeline.invoke_clean
+        pipeline.invoke
       }.to raise_error(Rake::Pipeline::TmpInputError)
     end
 

--- a/spec/rake_acceptance_spec.rb
+++ b/spec/rake_acceptance_spec.rb
@@ -231,7 +231,7 @@ HERE
           end
         end
 
-        project.invoke_clean
+        project.invoke
 
         expected = <<-HERE.gsub(/^ {10}/, '')
           var History = {};
@@ -247,12 +247,12 @@ HERE
       it "does not generate new files when things haven't changed" do
         output_file  = File.join(tmp, "public/javascripts/application.js")
 
-        project.invoke_clean
+        project.invoke
         previous_mtime = File.mtime(output_file)
 
         sleep 1
 
-        project.invoke_clean
+        project.invoke
         File.mtime(output_file).should == previous_mtime
       end
     end
@@ -518,7 +518,7 @@ HERE
   describe "Dynamic dependencies" do
     shared_examples_for "a pipeline with dynamic files" do
       it "should handle changes in dynamic imports" do
-        project.invoke_clean
+        project.invoke
 
         content = File.read output_file
 
@@ -532,14 +532,14 @@ HERE
           f.write "true to trance"
         end
 
-        project.invoke_clean
+        project.invoke
         content = File.read output_file
 
         content.should include("true to trance")
       end
 
       it "should handle changes in dynamic source files" do
-        project.invoke_clean
+        project.invoke
 
         content = File.read output_file
 
@@ -553,16 +553,16 @@ HERE
           f.write "true to trance"
         end
 
-        project.invoke_clean
+        project.invoke
         content = File.read output_file
 
         content.should == "true to trance"
       end
 
       it "should not regenerate files when nothing changes" do
-        project.invoke_clean
+        project.invoke
         previous_mtime = File.mtime output_file
-        sleep 1 ; project.invoke_clean
+        sleep 1 ; project.invoke
 
         File.mtime(output_file).should == previous_mtime
       end

--- a/tools/perfs
+++ b/tools/perfs
@@ -23,7 +23,7 @@ class Perfs < Thor
 
   class_option :clean, :type => :boolean, :default => true
 
-  desc "bench PROJECT_DIR", "Benchmark building, rebuilding, and cleaning the given project"
+  desc "bench PROJECT_DIR", "Benchmark building and cleaning the given project"
   def bench(project_dir)
     setup(project_dir)
 
@@ -31,20 +31,15 @@ class Perfs < Thor
       project.invoke
     end
 
-    reinvoke_time = Benchmark.realtime do
-      project.invoke_clean
-    end
-
     clean_time = Benchmark.realtime do
       project.clean
     end
 
     puts "build: #{invoke_time}"
-    puts "rebuild: #{reinvoke_time}"
     puts "clean: #{clean_time}"
   end
 
-  desc "profile PROJECT_DIR", "Profile a clean build of the given project"
+  desc "profile PROJECT_DIR", "Profile a build"
   method_option :rebuild, :type => :boolean, :aliases => "-r", :default => false
   def profile(project_dir)
     setup(project_dir)
@@ -52,7 +47,7 @@ class Perfs < Thor
     if options[:rebuild]
       project.invoke
       result = RubyProf.profile do
-        project.invoke_clean
+        project.invoke
       end
     else
       result = RubyProf.profile do
@@ -96,7 +91,6 @@ class Perfs < Thor
   def setup(project_dir)
     cd project_dir
     project.clean
-    project.invoke unless options[:clean]
   end
 
   def project


### PR DESCRIPTION
@wycats: this PR removes invoke_clean according to our conversation. I've also removed bits of code that are tied to the "is this a build or rebuild?" functionality. 

This commit creates a single entry point: project.invoke &
pipeline.invoke. Invoke can now handle these use cases correctly:
1. New files are detected and processed
2. Changes to the assetfile are reflected
3. Invoke'ing then invoke'ing again will not rebuild the files unless
   there have been changes
4. Any other previous use cases of invoke or invoke clean

The perf tools has also been updated
