### PR TITLE
Tmp error fix

### DIFF
--- a/lib/rake-pipeline.rb
+++ b/lib/rake-pipeline.rb
@@ -271,7 +271,11 @@ module Rake
 
         files.each do |file|
           relative_path = file.sub(%r{^#{Regexp.escape(expanded_root)}/}, '')
-          result << FileWrapper.new(expanded_root, relative_path)
+          wrapped_file = FileWrapper.new(expanded_root, relative_path)
+
+          raise TmpInputError, file if wrapped_file.in_directory?(tmpdir)
+
+          result << wrapped_file
         end
       end
 
@@ -344,12 +348,6 @@ module Rake
     # @return [void]
     # @api private
     def setup_filters
-      # First verify that everything can actually be an input
-      # FIXME: define eligible_input_files to filter out tmpfile
-      eligible_input_files.each do |file|
-        raise TmpInputError, file.fullpath if file.in_directory? tmpdir
-      end
-
       last = @filters.last
 
       @filters.inject(eligible_input_files) do |current_inputs, filter|

--- a/spec/pipeline_spec.rb
+++ b/spec/pipeline_spec.rb
@@ -159,14 +159,6 @@ describe "Rake::Pipeline" do
       pipeline.input_files.should == files
     end
 
-    it "raise an error when inputs are temporary_files" do
-      pipeline.input_files = [input_file("foo.bar", pipeline.tmpdir)]
-
-      expect {
-        pipeline.invoke
-      }.to raise_error(Rake::Pipeline::TmpInputError)
-    end
-
     it "configures the filters with outputs and inputs with #rake_tasks" do
       concat = ConcatFilter.new
       concat.output_name_generator = proc { |input| "javascripts/application.js" }


### PR DESCRIPTION
Refactor raising a TmpInputError when temporary files are passed between filters. I found this bug when testing master against iridium. The test suite didn't have pipelines complex enough to trigger this bug so I added a regression test. 
