### PR TITLE
Fix bug with nested matchers

### DIFF
--- a/lib/rake-pipeline.rb
+++ b/lib/rake-pipeline.rb
@@ -217,11 +217,12 @@ module Rake
     # @return [Pipeline] the new pipeline
     # @api private
     def copy(target_class=self.class, &block)
-      pipeline = target_class.build(&block)
+      pipeline = target_class.new
       pipeline.inputs = inputs
       pipeline.tmpdir = tmpdir
       pipeline.rake_application = rake_application
       pipeline.project = project
+      pipeline.build &block
       pipeline
     end
 

--- a/spec/rake_acceptance_spec.rb
+++ b/spec/rake_acceptance_spec.rb
@@ -603,4 +603,24 @@ HERE
       it_should_behave_like "a pipeline with dynamic files"
     end
   end
+
+  it "should work with nested matchers" do
+    project = Rake::Pipeline::Project.build do
+      tmpdir "temporary"
+      output "public"
+
+      input tmp, "app/**/*.js" do
+        match "**/*" do
+          match "**/*.js" do
+            filter strip_asserts_filter
+            concat "javascripts/application.js"
+          end
+        end
+      end
+    end
+
+    project.invoke_clean
+
+    output_should_exist
+  end
 end


### PR DESCRIPTION
Filters need a pipeline assigned to read a manifest from. Match calls
Pipeline#copy. #copy evaluates the block before assigning attributes
like pipeline and rake application. This commit changes copy to build up
the new instance correctly then evaluate the DSL block.
