### PR TITLE
Ensure files are read with the proper encoding

### DIFF
--- a/lib/rake-pipeline/file_wrapper.rb
+++ b/lib/rake-pipeline/file_wrapper.rb
@@ -110,7 +110,10 @@ module Rake
         # In our unit tests Rubinius returns false when the encoding is BINARY
         # The encoding type check bypasses the problem and is probably acceptable, but isn't ideal
         if encoding != "BINARY" && "".respond_to?(:encode) && !contents.valid_encoding?
-          raise EncodingError, "The file at the path #{fullpath} is not valid #{encoding}. Please save it again as #{encoding}."
+          contents.force_encoding("BINARY")
+          if !contents.valid_encoding?
+            raise EncodingError, "The file at the path #{fullpath} is not valid #{encoding}. Please save it again as #{encoding}."
+          end
         end
 
         contents
@@ -168,6 +171,7 @@ module Rake
       # @raise [UnopenedFile] if the file is not already opened.
       def write(string)
         raise UnopenedFile unless @created_file
+        @created_file.set_encoding string.encoding
         @created_file.write(string)
       end
 


### PR DESCRIPTION
This fixed the problems I had with copying binary files through the pipeline.
