### PR TITLE
Pin rake dependency to v10.1

### DIFF
--- a/rake-pipeline.gemspec
+++ b/rake-pipeline.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Rake::Pipeline::VERSION
 
-  gem.add_dependency "rake", "~> 10.0.0"
+  gem.add_dependency "rake", "~> 10.1.0"
   gem.add_dependency "thor"
   gem.add_dependency "json"
 


### PR DESCRIPTION
I've bumped the rake version so I can get `rake-pipeline` in to my app. Perhaps requiring `10.0 < rake < 10.2` would be more sensible?
